### PR TITLE
Add replace functionality

### DIFF
--- a/config/commands.json
+++ b/config/commands.json
@@ -219,6 +219,35 @@
                 ],
                 "level": 1
             },
+            "replace": {
+                "args": {
+                    "text": "(<query> | <specific>)",
+                    "description": [
+                        "<query> ~ Search terms for a song. Queues the first result from youtube.\n",
+                        "<specific> ~ <user_data>+ &| <yt_url> &| <sc_url> &| <playlist>+\n",
+                        "\t<user_data> ~ <user_permalink> <range>\n",
+                        "\t\t<user_permalink> ~ SoundCloud user permalink. (Checkout SoundCloud commands)\n",
+                        "\t\t<range> ~ Specifies range of the user's music list to use. Valid syntax is below.\n",
+                        "\t\t\t[X] ~ Means select the first X songs in the list (Most recent favorites)\n",
+                        "\t\t\t[-X] ~ Means select the last X songs in the list (Least recent favorites)\n",
+                        "\t\t\t[X,Y] ~ Select all songs from X to Y (X & Y can also be negative like above)\n",
+                        "\t\t\t[ALL] ~ Select all songs in the list\n",
+                        "\t<yt_url> ~ An url for a YouTube video or playlist\n",
+                        "\t<sc_url> ~ An url for a SoundCloud video or playlist\n",
+                        "\t<playlist> ~ pl.<playlistId>\n",
+                        "\t\t<playlistId> ~ An ID for a playlist you wish to add to the queue\n",
+                        "Optional Flags:\n",
+                        "\t--shuffle ~ Shuffle the new list before adding to the queue\n"
+                    ]
+                },
+                "detail": "Replace the queue",
+                "usage": [
+                    "add jack-belford-1 [all] --shuffle",
+                    "add https://www.youtube.com/watch?v=HEXWRTEbj1I",
+                    "add pl.ssp"
+                ],
+                "level": 1
+            },
             "clear": {
                 "detail": "Clear the queue",
                 "usage": [

--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -17,6 +17,22 @@ export function addQueueCommands(bot: DiscordBot, config: BotConfig, daos: Daos)
   const ytApi = new YoutubeAPI(config.tokens.youtube);
   const scApi = new SoundCloudAPI(config.tokens.soundcloud);
 
+  const add = async (message: Message, params: string[]) => {
+    try {
+      if (params.length === 0) return await message.reply("You didn't specify what to add!");
+      const queryResults = await Utils.songQuery(message, params.join(' '), scUsers, users, scApi, ytApi);
+      if (_.isNil(queryResults)) return;
+      await queuePlayerManager.get(message.guild.id).enqueue(queryResults.songs, queryResults.nextFlag);
+      const nameOrLength = queryResults.songs.length > 1 ? `${queryResults.songs.length} songs` : `**${queryResults.songs[0].title}**`;
+      let addedMsg = `Successfully added ${nameOrLength} `;
+      addedMsg += queryResults.nextFlag ? 'to be played next!' : 'to the queue!';
+      await message.reply(addedMsg);
+    } catch (e) {
+      await message.reply(`Failed to add anything to the queue.`);
+      console.log(e);
+    }
+  }
+
   const commands: { [x: string]: (message: Message, params: string[], level: number) => any } = {
 
     'show': async (message: Message) => {
@@ -37,40 +53,16 @@ export function addQueueCommands(bot: DiscordBot, config: BotConfig, daos: Daos)
     },
 
     'add': async (message: Message, params: string[]) => {
-      try {
-        if (params.length === 0) return await message.reply("You didn't specify what to add!");
-        const queryResults = await Utils.songQuery(message, params.join(' '), scUsers, users, scApi, ytApi);
-        if (_.isNil(queryResults)) return;
-        await queuePlayerManager.get(message.guild.id).enqueue(queryResults.songs, queryResults.nextFlag);
-        const nameOrLength = queryResults.songs.length > 1 ? `${queryResults.songs.length} songs` : `**${queryResults.songs[0].title}**`;
-        let addedMsg = `Successfully added ${nameOrLength} `;
-        addedMsg += queryResults.nextFlag ? 'to be played next!' : 'to the queue!';
-        await message.reply(addedMsg);
-      } catch (e) {
-        await message.reply(`Failed to add anything to the queue.`);
-        console.log(e);
-      }
+      add(message, params)
     },
 
     'replace': async (message: Message, params: string[]) => {
       const queuePlayer = queuePlayerManager.get(message.guild.id);
       if (queuePlayer.queuedTracks !== 0) {
         await queuePlayer.clear();
-        await message.reply('The queue is already empty though...');
+        await message.reply('I have cleared the queue');
       }
-      try {
-        if (params.length === 0) return await message.reply("You didn't specify what to add!");
-        const queryResults = await Utils.songQuery(message, params.join(' '), scUsers, users, scApi, ytApi);
-        if (_.isNil(queryResults)) return;
-        await queuePlayerManager.get(message.guild.id).enqueue(queryResults.songs, queryResults.nextFlag);
-        const nameOrLength = queryResults.songs.length > 1 ? `${queryResults.songs.length} songs` : `**${queryResults.songs[0].title}**`;
-        let addedMsg = `Successfully added ${nameOrLength} `;
-        addedMsg += queryResults.nextFlag ? 'to be played next!' : 'to the queue!';
-        await message.reply(addedMsg);
-      } catch (e) {
-        await message.reply(`Failed to add anything to the queue.`);
-        console.log(e);
-      }
+      add(message, params)
     },
   }
 

--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -17,15 +17,33 @@ export function addQueueCommands(bot: DiscordBot, config: BotConfig, daos: Daos)
   const ytApi = new YoutubeAPI(config.tokens.youtube);
   const scApi = new SoundCloudAPI(config.tokens.soundcloud);
 
-  const add = async (message: Message, params: string[]) => {
+  const insertToQueue = async (mode: string, message: Message, params: string[]) => {
     try {
       if (params.length === 0) return await message.reply("You didn't specify what to add!");
       const queryResults = await Utils.songQuery(message, params.join(' '), scUsers, users, scApi, ytApi);
       if (_.isNil(queryResults)) return;
-      await queuePlayerManager.get(message.guild.id).enqueue(queryResults.songs, queryResults.nextFlag);
-      const nameOrLength = queryResults.songs.length > 1 ? `${queryResults.songs.length} songs` : `**${queryResults.songs[0].title}**`;
-      let addedMsg = `Successfully added ${nameOrLength} `;
-      addedMsg += queryResults.nextFlag ? 'to be played next!' : 'to the queue!';
+      let addedMsg: string;
+      if (mode === 'add') {
+        await queuePlayerManager.get(message.guild.id).enqueue(queryResults.songs, queryResults.nextFlag);
+        const nameOrLength = queryResults.songs.length > 1 ? `${queryResults.songs.length} songs` : `**${queryResults.songs[0].title}**`;
+        addedMsg = `Successfully added ${nameOrLength} `;
+        addedMsg += queryResults.nextFlag ? 'to be played next!' : 'to the queue!';
+      }
+      if (mode === 'replace') {
+        const queuePlayer = queuePlayerManager.get(message.guild.id);
+        if (queuePlayer.queuedTracks !== 0) {
+          await queuePlayer.clear();
+        }
+        await queuePlayerManager.get(message.guild.id).enqueue(queryResults.songs, queryResults.nextFlag);
+        let replaceWith: string;
+        if (queryResults.songs.length > 1) {
+          replaceWith = `${queryResults.playlists.join(", ")} (${queryResults.songs.length} songs)`;
+        } else {
+          replaceWith = `**${queryResults.songs[0].title}**`;
+        }
+        addedMsg = `Successfully replaced queue with ${replaceWith}!`;
+      }
+      
       await message.reply(addedMsg);
     } catch (e) {
       await message.reply(`Failed to add anything to the queue.`);
@@ -53,16 +71,11 @@ export function addQueueCommands(bot: DiscordBot, config: BotConfig, daos: Daos)
     },
 
     'add': async (message: Message, params: string[]) => {
-      add(message, params)
+      insertToQueue('add', message, params)
     },
 
     'replace': async (message: Message, params: string[]) => {
-      const queuePlayer = queuePlayerManager.get(message.guild.id);
-      if (queuePlayer.queuedTracks !== 0) {
-        await queuePlayer.clear();
-        await message.reply('I have cleared the queue');
-      }
-      add(message, params)
+      insertToQueue('replace', message, params)
     },
   }
 

--- a/src/commands/queue.ts
+++ b/src/commands/queue.ts
@@ -28,25 +28,27 @@ export function addQueueCommands(bot: DiscordBot, config: BotConfig, daos: Daos)
       const queryResults = await Utils.songQuery(message, params.join(' '), scUsers, users, scApi, ytApi);
       if (_.isNil(queryResults)) return;
       let addedMsg: string;
-      if (mode === InsertionMode.Add) {
-        await queuePlayerManager.get(message.guild.id).enqueue(queryResults.songs, queryResults.nextFlag);
-        const nameOrLength = queryResults.songs.length > 1 ? `${queryResults.songs.length} songs` : `**${queryResults.songs[0].title}**`;
-        addedMsg = `Successfully added ${nameOrLength} `;
-        addedMsg += queryResults.nextFlag ? 'to be played next!' : 'to the queue!';
-      }
-      if (mode === InsertionMode.Replace) {
-        const queuePlayer = queuePlayerManager.get(message.guild.id);
-        if (queuePlayer.queuedTracks !== 0) {
-          await queuePlayer.clear();
-        }
-        await queuePlayerManager.get(message.guild.id).enqueue(queryResults.songs, queryResults.nextFlag);
-        let replaceWith: string;
-        if (queryResults.songs.length > 1) {
-          replaceWith = `${queryResults.playlists.join(", ")} (${queryResults.songs.length} songs)`;
-        } else {
-          replaceWith = `**${queryResults.songs[0].title}**`;
-        }
-        addedMsg = `Successfully replaced queue with ${replaceWith}!`;
+      switch (mode) {
+        case InsertionMode.Add:
+          await queuePlayerManager.get(message.guild.id).enqueue(queryResults.songs, queryResults.nextFlag);
+          const nameOrLength = queryResults.songs.length > 1 ? `${queryResults.songs.length} songs` : `**${queryResults.songs[0].title}**`;
+          addedMsg = `Successfully added ${nameOrLength} `;
+          addedMsg += queryResults.nextFlag ? 'to be played next!' : 'to the queue!';
+          break;
+        case InsertionMode.Replace:
+          const queuePlayer = queuePlayerManager.get(message.guild.id);
+          if (queuePlayer.queuedTracks !== 0) {
+            await queuePlayer.clear();
+          }
+          await queuePlayer.enqueue(queryResults.songs, queryResults.nextFlag);
+          let replaceWith: string;
+          if (queryResults.songs.length > 1) {
+            replaceWith = `${queryResults.playlists.join(", ")} (${queryResults.songs.length} songs)`;
+          } else {
+            replaceWith = `**${queryResults.songs[0].title}**`;
+          }
+          addedMsg = `Successfully replaced queue with ${replaceWith}!`;
+          break;
       }
       
       await message.reply(addedMsg);


### PR DESCRIPTION
Adding a replace function to queue (had not test it on actual server yet). 

Reasoning:
We usually want to switch playlists, so it makes sense to have replace functionality for queue. 

Modifications:
Adds replace in `src/commands/queue.ts` as a modified clear followed by add
Adds documentation in commands.json using add as template (same except no "--next" option). 